### PR TITLE
Update version.rb

### DIFF
--- a/lib/inheritable_fixtures/version.rb
+++ b/lib/inheritable_fixtures/version.rb
@@ -1,3 +1,3 @@
 module InheritableFixtures
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
`0.5.0` has already been released.  This commit corrects the version to align with that. There are no other code changes since the `0.5.0` release so this is accurate